### PR TITLE
Fix unsafe Config.extra access & add directive to suppress ESLint

### DIFF
--- a/pydantic2ts/cli/script.py
+++ b/pydantic2ts/cli/script.py
@@ -141,25 +141,28 @@ def generate_json_schema(models: List[Type[BaseModel]]) -> str:
     '[k: string]: any' from being added to every interface. This change is reverted
     once the schema has been generated.
     """
-    model_extras = [m.Config.extra for m in models]
+    model_extras = [getattr(m.Config, 'extra', None) for m in models]
 
-    for m in models:
-        if m.Config.extra != Extra.allow:
-            m.Config.extra = Extra.forbid
+    try:
+        for m in models:
+            if getattr(m.Config, 'extra', None) != Extra.allow:
+                m.Config.extra = Extra.forbid
 
-    master_model = create_model("_Master_", **{m.__name__: (m, ...) for m in models})
-    master_model.Config.extra = Extra.forbid
-    master_model.Config.schema_extra = staticmethod(clean_schema)
+        master_model = create_model("_Master_", **{m.__name__: (m, ...) for m in models})
+        master_model.Config.extra = Extra.forbid
+        master_model.Config.schema_extra = staticmethod(clean_schema)
 
-    schema = json.loads(master_model.schema_json())
+        schema = json.loads(master_model.schema_json())
 
-    for d in schema.get("definitions", {}).values():
-        clean_schema(d)
+        for d in schema.get("definitions", {}).values():
+            clean_schema(d)
 
-    for m, x in zip(models, model_extras):
-        m.Config.extra = x
+        return json.dumps(schema, indent=2)
 
-    return json.dumps(schema, indent=2)
+    finally:
+        for m, x in zip(models, model_extras):
+            if x is not None:
+                m.Config.extra = x
 
 
 def generate_typescript_defs(

--- a/pydantic2ts/cli/script.py
+++ b/pydantic2ts/cli/script.py
@@ -199,6 +199,7 @@ def generate_typescript_defs(
     banner_comment = "\n".join(
         [
             "/* tslint:disable */",
+            "/* eslint-disable */",
             "/**",
             "/* This file was automatically generated from pydantic models by running pydantic2ts.",
             "/* Do not modify it by hand - just update the pydantic models and then re-run the script",


### PR DESCRIPTION
Intended to resolve #3.  The PR replaces both direct accesses to the Config.extra attribute with a getattr.  I also wrapped the main body of the function in a `try/finally` to ensure that the cleanup code gets run.

Finally, and unrelatedly, I also added a linter directive to turn off ESLint on the generated file.