### PR TITLE
Remove root logger configuration

### DIFF
--- a/pydantic2ts/cli/script.py
+++ b/pydantic2ts/cli/script.py
@@ -19,8 +19,6 @@ try:
 except ImportError:
     GenericModel = None
 
-logging.basicConfig(level=logging.DEBUG, format="%(asctime)s %(message)s")
-
 logger = logging.getLogger("pydantic2ts")
 
 

--- a/pydantic2ts/cli/script.py
+++ b/pydantic2ts/cli/script.py
@@ -221,6 +221,8 @@ def main(module: str, output: str, json2ts_cmd: str = "json2ts") -> None:
     """
     CLI entrypoint to run :func:`generate_typescript_defs`
     """
+    logging.basicConfig(level=logging.DEBUG, format="%(asctime)s %(message)s")
+
     return generate_typescript_defs(module, output, json2ts_cmd)
 
 


### PR DESCRIPTION
Just found this library and started implementing it in an app I'm building - thanks for writing this! One thing I ran into was that the library sets a configuration for the root logger to log at the debug level and propagates to all other loggers. This resulted in other imported libraries also logging at the debug level (which I didn't want).

I found [this section](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library) in the official documentation that recommends against calling `logging.basicConfig` in libraries and letting the application configure logging. (Which I found from this [SO answer](https://stackoverflow.com/a/27017068)).

Let me know what you think!