### PR TITLE
Check whether json2ts exited without any errors before processing the generated ts file

### DIFF
--- a/pydantic2ts/cli/script.py
+++ b/pydantic2ts/cli/script.py
@@ -210,13 +210,17 @@ def generate_typescript_defs(
             "*/",
         ]
     )
-    os.system(
+    status = os.system(
         f'{json2ts_cmd} -i {schema_file_path} -o {output} --bannerComment "{banner_comment}"'
     )
-    shutil.rmtree(schema_dir)
-    remove_master_model_from_output(output)
 
-    logger.info(f"Saved typescript definitions to {output}.")
+    if status == 0:
+        remove_master_model_from_output(output)
+        logger.info(f"Saved typescript definitions to {output}.")
+    else:
+        logger.error(f"{json2ts_cmd} failed with exit code {status}.")
+
+    shutil.rmtree(schema_dir)
 
 
 @click.command()

--- a/pydantic2ts/cli/script.py
+++ b/pydantic2ts/cli/script.py
@@ -209,11 +209,11 @@ def generate_typescript_defs(
         f.write(schema)
 
     logger.info("Converting JSON schema to typescript definitions...")
-    
+
     json2ts_exit_code = os.system(
         f'{json2ts_cmd} -i {schema_file_path} -o {output} --bannerComment ""'
     )
-    
+
     if json2ts_exit_code == 0:
         remove_master_model_from_output(output)
         logger.info(f"Saved typescript definitions to {output}.")


### PR DESCRIPTION
json2ts started failing on my machine due to some hard to reproduce issue related  running x86 binaries on an m1 mac. However since the output file was still there (it previously worked fine) pydantic-to-typescript still attempted to call 'remove_master_model_from_output' on it and failed with this message as a result:

line 111, in remove_master_model_from_output
new_lines = lines[:start] + lines[(end + 1) :]
TypeError: unsupported operand type(s) for +: ‘NoneType’ and ‘int’

(the error is the same as in https://github.com/phillipdupuis/pydantic-to-typescript/issues/5, not sure if it's caused by the same issue)

because obviously the master model was already stripped. This was confusing and it took me some time to figure out that json2ts was failling.




