### PR TITLE
✨🚇 Add CI/CD  pipeline

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,69 @@
+name: "Tests"
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: Test pyglotaran stable
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        python-version: ["3.8"]
+        include:
+          - os: ubuntu-latest
+            python-version: "3.6"
+          - os: ubuntu-latest
+            python-version: "3.7"
+          - os: ubuntu-latest
+            python-version: "3.9"
+          - os: ubuntu-latest
+            python-version: "3.10"
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+      - name: Set up Node.js 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install json-schema-to-typescript
+        run: |
+          npm i -g json-schema-to-typescript
+      - name: Install python dependencies
+        run: |
+          python -m pip install -U pip wheel pytest
+          python -m pip install -U .
+      - name: Run tests
+        run: |
+          python -m pytest
+
+  deploy:
+    name: Deploy to PyPi
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+    needs: test
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip wheel
+      - name: Build dist
+        run: |
+          python setup.py sdist bdist_wheel
+
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@v1.5.0
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,11 +38,11 @@ jobs:
           npm i -g json-schema-to-typescript
       - name: Install python dependencies
         run: |
-          python -m pip install -U pip wheel pytest
+          python -m pip install -U pip wheel pytest pytest-cov
           python -m pip install -U .
       - name: Run tests
         run: |
-          python -m pytest
+          python -m pytest --cov=pydantic2ts
 
   deploy:
     name: Deploy to PyPi

--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ cython_debug/
 # my stuff
 .idea
 .private.txt
+
+# VS Code config
+.vscode

--- a/README.md
+++ b/README.md
@@ -1,27 +1,35 @@
 # pydantic-to-typescript
 
 [![PyPI version](https://badge.fury.io/py/pydantic-to-typescript.svg)](https://badge.fury.io/py/pydantic-to-typescript)
+[![Tests](https://github.com/phillipdupuis/pydantic-to-typescript/actions/workflows/tests.yml/badge.svg)](https://github.com/phillipdupuis/pydantic-to-typescript/actions/workflows/tests.yml)
 
 A simple CLI tool for converting pydantic models into typescript interfaces. Useful for any scenario in which python and javascript applications are interacting, since it allows you to have a single source of truth for type definitions.
 
 This tool requires that you have the lovely json2ts CLI utility installed. Instructions can be found here: https://www.npmjs.com/package/json-schema-to-typescript
 
 ### Installation
+
 ```bash
 $ pip install pydantic-to-typescript
 ```
+
 ---
+
 ### CLI
 
-|Prop|Description|
-|:----------|:-----------|
-|&#8209;&#8209;module|name or filepath of the python module you would like to convert. All the pydantic models within it will be converted to typescript interfaces. Discoverable submodules will also be checked.|
-|&#8209;&#8209;output|name of the file the typescript definitions should be written to. Ex: './frontend/apiTypes.ts'|
-|&#8209;&#8209;exclude|name of a pydantic model which should be omitted from the resulting typescript definitions. This option can be defined multiple times, ex: `--exclude Foo --exclude Bar` to exclude both the Foo and Bar models from the output.|
-|&#8209;&#8209;json2ts&#8209;cmd|optional, the command used to invoke json2ts. The default is 'json2ts'. Specify this if you have it installed in a strange location and need to provide the exact path (ex: /myproject/node_modules/bin/json2ts)|
+| Prop                            | Description                                                                                                                                                                                                                      |
+| :------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| &#8209;&#8209;module            | name or filepath of the python module you would like to convert. All the pydantic models within it will be converted to typescript interfaces. Discoverable submodules will also be checked.                                     |
+| &#8209;&#8209;output            | name of the file the typescript definitions should be written to. Ex: './frontend/apiTypes.ts'                                                                                                                                   |
+| &#8209;&#8209;exclude           | name of a pydantic model which should be omitted from the resulting typescript definitions. This option can be defined multiple times, ex: `--exclude Foo --exclude Bar` to exclude both the Foo and Bar models from the output. |
+| &#8209;&#8209;json2ts&#8209;cmd | optional, the command used to invoke json2ts. The default is 'json2ts'. Specify this if you have it installed in a strange location and need to provide the exact path (ex: /myproject/node_modules/bin/json2ts)                 |
+
 ---
+
 ### Usage
+
 Define your pydantic models (ex: /backend/api.py):
+
 ```python
 from fastapi import FastAPI
 from pydantic import BaseModel
@@ -47,15 +55,21 @@ def login(body: LoginCredentials):
     profile = Profile(**body.dict(), age=72, hobbies=['cats'])
     return LoginResponseData(token='very-secure', profile=profile)
 ```
+
 Execute the command for converting these models into typescript definitions, via:
+
 ```bash
 $ pydantic2ts --module backend.api --output ./frontend/apiTypes.ts
 ```
+
 or:
+
 ```bash
 $ pydantic2ts --module ./backend/api.py --output ./frontend/apiTypes.ts
 ```
+
 or:
+
 ```python
 from pydantic2ts import generate_typescript_defs
 
@@ -63,6 +77,7 @@ generate_typescript_defs("backend.api", "./frontend/apiTypes.ts")
 ```
 
 The models are now defined in typescript...
+
 ```ts
 /* tslint:disable */
 /**
@@ -84,19 +99,21 @@ export interface Profile {
   hobbies: string[];
 }
 ```
+
 ...and can be used in your typescript code with complete confidence.
+
 ```ts
-import { LoginCredentials, LoginResponseData } from './apiTypes.ts';
+import { LoginCredentials, LoginResponseData } from "./apiTypes.ts";
 
 async function login(
   credentials: LoginCredentials,
   resolve: (data: LoginResponseData) => void,
-  reject: (error: string) => void,
+  reject: (error: string) => void
 ) {
   try {
-    const response: Response = await fetch('/login/', {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
+    const response: Response = await fetch("/login/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify(credentials),
     });
     const data: LoginResponseData = await response.json();

--- a/pydantic2ts/cli/script.py
+++ b/pydantic2ts/cli/script.py
@@ -106,7 +106,16 @@ def remove_master_model_from_output(output: str) -> None:
             end = i
             break
 
-    new_lines = lines[:start] + lines[(end + 1) :]
+    banner_comment_lines = [
+        "/* tslint:disable */\n",
+        "/* eslint-disable */\n",
+        "/**\n",
+        "/* This file was automatically generated from pydantic models by running pydantic2ts.\n",
+        "/* Do not modify it by hand - just update the pydantic models and then re-run the script\n",
+        "*/\n\n",
+    ]
+
+    new_lines = banner_comment_lines + lines[:start] + lines[(end + 1) :]
     with open(output, "w") as f:
         f.writelines(new_lines)
 
@@ -200,18 +209,8 @@ def generate_typescript_defs(
 
     logger.info("Converting JSON schema to typescript definitions...")
 
-    banner_comment = "\n".join(
-        [
-            "/* tslint:disable */",
-            "/* eslint-disable */",
-            "/**",
-            "/* This file was automatically generated from pydantic models by running pydantic2ts.",
-            "/* Do not modify it by hand - just update the pydantic models and then re-run the script",
-            "*/",
-        ]
-    )
     os.system(
-        f'{json2ts_cmd} -i {schema_file_path} -o {output} --bannerComment "{banner_comment}"'
+        f'{json2ts_cmd} -i {schema_file_path} -o {output} --bannerComment ""'
     )
     shutil.rmtree(schema_dir)
     remove_master_model_from_output(output)

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from pydantic2ts import generate_typescript_defs
 
 
@@ -23,6 +24,9 @@ def run_test(
     Execute pydantic2ts logic for converting pydantic models into tyepscript definitions.
     Compare the output with the expected output, verifying it is identical.
     """
+    # Literal was only introduced in python 3.8 (Ref.: PEP 586) so tests break
+    if sys.version_info < (3, 8) and test_name == "submodules":
+        return
     module_path = module_path or get_input_module(test_name)
     output_path = tmpdir.join(f"cli_{test_name}.ts").strpath
 

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import subprocess
 from pydantic2ts import generate_typescript_defs
 
 
@@ -36,7 +37,7 @@ def run_test(
         cmd = f"pydantic2ts --module {module_path} --output {output_path}"
         for model_to_exclude in exclude:
             cmd += f" --exclude {model_to_exclude}"
-        os.system(cmd)
+        subprocess.run(cmd, shell=True)
 
     with open(output_path, "r") as f:
         output = f.read()

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -28,6 +28,10 @@ def run_test(
     # Literal was only introduced in python 3.8 (Ref.: PEP 586) so tests break
     if sys.version_info < (3, 8) and test_name == "submodules":
         return
+    # GenericModel is only supported for python>=3.7
+    # (Ref.: https://pydantic-docs.helpmanual.io/usage/models/#generic-models)
+    if sys.version_info < (3, 7) and test_name == "generics":
+        return
     module_path = module_path or get_input_module(test_name)
     output_path = tmpdir.join(f"cli_{test_name}.ts").strpath
 

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -68,7 +68,7 @@ def test_excluding_models(tmpdir):
 
 def test_relative_filepath(tmpdir):
     test_name = "single_module"
-    relative_path = os.path.join(".", "expected_results", test_name, "input.py")
+    relative_path = os.path.join(".", "tests", "expected_results", test_name, "input.py")
     run_test(
         tmpdir, "single_module", module_path=relative_path,
     )


### PR DESCRIPTION
Thanks for the awesome tool, this is precisely what I was looking for 🎉😄 

I thought you might enjoy a CI/CD pipeline that automatically runs tests on PRs and deploys the package to PyPI when you push a tag (e.g. when creating a release on the [github release page](https://github.com/phillipdupuis/pydantic-to-typescript/releases)).
I also found a bug on windows where only the first line of the banner was added to the file since windows shells don't like multiline strings.

For the CD pipeline to work you need to get a token from PyPI and set `pypi_password` as [secret in your repository settings](https://github.com/phillipdupuis/pydantic-to-typescript/settings/secrets/actions).

Here is an [example what the CI run looks like](https://github.com/s-weigand/pydantic-to-typescript/actions/runs/2493374685)