### PR TITLE
CICD updates for linting with black, code coverage, and cleaning up naming conventions

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,12 +1,17 @@
-name: "Tests"
-
+name: CI/CD
 on:
   push:
   pull_request:
-
 jobs:
+  lint:
+    name: Lint code with black
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: psf/black@stable
   test:
-    name: Test pyglotaran stable
+    name: Run unit tests
+    needs: lint
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -21,7 +26,6 @@ jobs:
             python-version: "3.9"
           - os: ubuntu-latest
             python-version: "3.10"
-
     steps:
       - name: Check out repo
         uses: actions/checkout@v3
@@ -38,12 +42,21 @@ jobs:
           npm i -g json-schema-to-typescript
       - name: Install python dependencies
         run: |
-          python -m pip install -U pip wheel pytest pytest-cov
+          python -m pip install -U pip wheel pytest pytest-cov coverage
           python -m pip install -U .
       - name: Run tests
         run: |
           python -m pytest --cov=pydantic2ts
-
+      - name: Generate LCOV File
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8' }}
+        run: |
+          coverage lcov
+      - name: Coveralls
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8' }}
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: coverage.lcov
   deploy:
     name: Deploy to PyPi
     runs-on: ubuntu-latest
@@ -61,7 +74,6 @@ jobs:
       - name: Build dist
         run: |
           python setup.py sdist bdist_wheel
-
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@v1.5.0
         with:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![PyPI version](https://badge.fury.io/py/pydantic-to-typescript.svg)](https://badge.fury.io/py/pydantic-to-typescript)
 [![Tests](https://github.com/phillipdupuis/pydantic-to-typescript/actions/workflows/tests.yml/badge.svg)](https://github.com/phillipdupuis/pydantic-to-typescript/actions/workflows/tests.yml)
+[![Coverage Status](https://coveralls.io/repos/github/phillipdupuis/pydantic-to-typescript/badge.svg?branch=master)](https://coveralls.io/github/phillipdupuis/pydantic-to-typescript?branch=master)
 
 A simple CLI tool for converting pydantic models into typescript interfaces. Useful for any scenario in which python and javascript applications are interacting, since it allows you to have a single source of truth for type definitions.
 

--- a/pydantic2ts/cli/script.py
+++ b/pydantic2ts/cli/script.py
@@ -116,6 +116,7 @@ def remove_master_model_from_output(output: str) -> None:
     ]
 
     new_lines = banner_comment_lines + lines[:start] + lines[(end + 1) :]
+
     with open(output, "w") as f:
         f.writelines(new_lines)
 
@@ -209,9 +210,7 @@ def generate_typescript_defs(
 
     logger.info("Converting JSON schema to typescript definitions...")
 
-    os.system(
-        f'{json2ts_cmd} -i {schema_file_path} -o {output} --bannerComment ""'
-    )
+    os.system(f'{json2ts_cmd} -i {schema_file_path} -o {output} --bannerComment ""')
     shutil.rmtree(schema_dir)
     remove_master_model_from_output(output)
 

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,11 @@ setup(
     author="Phillip Dupuis",
     author_email="phillip_dupuis@alumni.brown.edu",
     url="https://github.com/phillipdupuis/pydantic-to-typescript",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests*"]),
     install_requires=install_requires,
+    extras_require={
+        "dev": ["pytest", "pytest-cov", "coverage"],
+    },
     entry_points={"console_scripts": ["pydantic2ts = pydantic2ts.cli.script:main"]},
     classifiers=classifiers,
 )


### PR DESCRIPTION
Added a CI/CD job for linting with black, a test stage for uploading coverage reports to coveralls, and cleaned up naming conventions as well as the logic for conditionally skipping tests based on the python version.