### PR TITLE
The --json2ts-cmd option should not be validated via 'shutil.which'

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ pip install pydantic-to-typescript
 | &#8209;&#8209;module            | name or filepath of the python module you would like to convert. All the pydantic models within it will be converted to typescript interfaces. Discoverable submodules will also be checked.                                     |
 | &#8209;&#8209;output            | name of the file the typescript definitions should be written to. Ex: './frontend/apiTypes.ts'                                                                                                                                   |
 | &#8209;&#8209;exclude           | name of a pydantic model which should be omitted from the resulting typescript definitions. This option can be defined multiple times, ex: `--exclude Foo --exclude Bar` to exclude both the Foo and Bar models from the output. |
-| &#8209;&#8209;json2ts&#8209;cmd | optional, the command used to invoke json2ts. The default is 'json2ts'. Specify this if you have it installed in a strange location and need to provide the exact path (ex: /myproject/node_modules/bin/json2ts)                 |
+| &#8209;&#8209;json2ts&#8209;cmd | optional, the command used to invoke json2ts. The default is 'json2ts'. Specify this if you have it installed locally (ex: 'yarn json2ts') or if the exact path to the executable is required (ex: /myproject/node_modules/bin/json2ts)                 |
 
 ---
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
@@ -25,7 +25,7 @@ install_requires = [
 
 setup(
     name="pydantic-to-typescript",
-    version="1.0.9",
+    version="1.0.10",
     description="Convert pydantic models to typescript interfaces",
     license="MIT",
     long_description=readme(),

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -101,15 +101,35 @@ def test_calling_from_python(tmpdir):
 
 
 def test_error_if_json2ts_not_installed(tmpdir):
-    with pytest.raises(Exception) as exc:
-        module_path = get_input_module("single_module")
-        output_path = tmpdir.join(f"cli_single_module.ts").strpath
-        json2ts_cmd = "someCommandWhichDefinitelyDoesNotExist"
-        generate_typescript_defs(module_path, output_path, json2ts_cmd=json2ts_cmd)
+    module_path = get_input_module("single_module")
+    output_path = tmpdir.join(f"cli_single_module.ts").strpath
+
+    # If the json2ts command has no spaces and the executable cannot be found,
+    # that means the user either hasn't installed json-schema-to-typescript or they made a typo.
+    # We should raise a descriptive error with installation instructions.
+    invalid_global_cmd = "someCommandWhichDefinitelyDoesNotExist"
+    with pytest.raises(Exception) as exc1:
+        generate_typescript_defs(
+            module_path,
+            output_path,
+            json2ts_cmd=invalid_global_cmd,
+        )
     assert (
-        str(exc.value)
-        == "json2ts must be installed. Instructions can be found here: https://www.npmjs.com/package/json-schema-to-typescript"
+        str(exc1.value)
+        == "json2ts must be installed. Instructions can be founds here: https://www.npmjs.com/package/json-schema-to-typescript"
     )
+
+    # But if the command DOES contain spaces (ex: "yarn json2ts") they're likely using a locally installed CLI.
+    # We should not be validating the command in this case.
+    # Instead we should just be *trying* to run it and checking the exit code.
+    invalid_local_cmd = "yaaaarn json2tsbutwithatypo"
+    with pytest.raises(RuntimeError) as exc2:
+        generate_typescript_defs(
+            module_path,
+            output_path,
+            json2ts_cmd=invalid_local_cmd,
+        )
+    assert str(exc2.value).startswith(f'"{invalid_local_cmd}" failed with exit code ')
 
 
 def test_error_if_invalid_module_path(tmpdir):

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -116,7 +116,7 @@ def test_error_if_json2ts_not_installed(tmpdir):
         )
     assert (
         str(exc1.value)
-        == "json2ts must be installed. Instructions can be founds here: https://www.npmjs.com/package/json-schema-to-typescript"
+        == "json2ts must be installed. Instructions can be found here: https://www.npmjs.com/package/json-schema-to-typescript"
     )
 
     # But if the command DOES contain spaces (ex: "yarn json2ts") they're likely using a locally installed CLI.


### PR DESCRIPTION
This validation should not be applied if the provided command contains spaces (ex: 'yarn json2ts').

In those cases we will just attempt to run it, and if the command fails we will raise a RuntimeError noting that.