### PR TITLE
Fix generation for empty list of models

### DIFF
--- a/pydantic2ts/cli/script.py
+++ b/pydantic2ts/cli/script.py
@@ -105,6 +105,8 @@ def clean_output_file(output_filename: str) -> None:
     for i, line in enumerate(lines):
         if line.rstrip("\r\n") == "export interface _Master_ {":
             start = i
+        elif line.rstrip("\r\n") == "export interface _Master_ {}":
+            start = i
         elif (start is not None) and line.rstrip("\r\n") == "}":
             end = i
             break


### PR DESCRIPTION
Turns out, if the list of models is empty, a line

export interface Master {}

is generated

**Yes**, I know this is an edge case, but having this simplifies the handling of projects with many (potentially empty) modules. 