### PR TITLE
Updates for newest pydantic

### DIFF
--- a/pydantic2ts/cli/script.py
+++ b/pydantic2ts/cli/script.py
@@ -64,9 +64,7 @@ def is_concrete_pydantic_model(obj) -> bool:
     if not inspect.isclass(obj):
         return False
     elif obj is BaseModel:
-        return False
-    elif GenericModel and issubclass(obj, GenericModel):
-        return bool(obj.__concrete__)
+        return getattr(obj, "__concrete__", False)
     else:
         return issubclass(obj, BaseModel)
 
@@ -152,18 +150,18 @@ def generate_json_schema(models: List[Type[BaseModel]]) -> str:
     '[k: string]: any' from being added to every interface. This change is reverted
     once the schema has been generated.
     """
-    model_extras = [getattr(m.Config, "extra", None) for m in models]
+    model_extras = [m.model_config.get("extra", None) for m in models]
 
     try:
         for m in models:
-            if getattr(m.Config, "extra", None) != Extra.allow:
-                m.Config.extra = Extra.forbid
+            if m.model_config.get("extra", None) != Extra.allow:
+                m.model_config["extra"] = Extra.forbid
 
         master_model = create_model(
-            "_Master_", **{m.__name__: (m, ...) for m in models}
+            "_Master_", **{m.__name__: (m, ...) for m in models}, __base__=m
         )
-        master_model.Config.extra = Extra.forbid
-        master_model.Config.schema_extra = staticmethod(clean_schema)
+        master_model.model_config["extra"] = Extra.forbid
+        master_model.model_config["schema_extra"] = staticmethod(clean_schema)
 
         schema = json.loads(master_model.schema_json())
 
@@ -175,7 +173,7 @@ def generate_json_schema(models: List[Type[BaseModel]]) -> str:
     finally:
         for m, x in zip(models, model_extras):
             if x is not None:
-                m.Config.extra = x
+                m.model_config.extra = x
 
 
 def generate_typescript_defs(

--- a/pydantic2ts/cli/script.py
+++ b/pydantic2ts/cli/script.py
@@ -173,7 +173,7 @@ def generate_json_schema(models: List[Type[BaseModel]]) -> str:
     finally:
         for m, x in zip(models, model_extras):
             if x is not None:
-                m.model_config.extra = x
+                m.model_config["extra"] = x
 
 
 def generate_typescript_defs(


### PR DESCRIPTION
- Use ducktyping for Generic Models
- use `model_config` instead of `Config` attr