### PR TITLE
Require `--module` and `--output`

### DIFF
--- a/pydantic2ts/cli/script.py
+++ b/pydantic2ts/cli/script.py
@@ -242,10 +242,12 @@ def parse_cli_args(args: List[str] = None) -> argparse.Namespace:
         "--module",
         help="name or filepath of the python module.\n"
         "Discoverable submodules will also be checked.",
+        required=True,
     )
     parser.add_argument(
         "--output",
         help="name of the file the typescript definitions should be written to.",
+        required=True,
     )
     parser.add_argument(
         "--exclude",


### PR DESCRIPTION
Otherwise the program will happily try to write to a file called `None`.