### PR TITLE
Feat: add new `--all-fields-required` flag (addresses #28: Field with default value becomes optional)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,13 +153,13 @@ from pydantic import BaseModel, Field
 from typing import Annotated, Literal, Optional
 
 class ExampleModel(BaseModel):
-    a: Annotated[int, Field(default=2)]
-    b: Annotated[list[int], Field(default_factory=list)]
-    c: Literal["c"] = "c"
-    d: int = 1
-    e: Optional[int]
-    f: Optional[int] = None
-    g: Optional[int] = 3
+    literal_str_with_default: Literal["c"] = "c"
+    int_with_default: int = 1
+    int_with_pydantic_default: Annotated[int, Field(default=2)]
+    int_list_with_default_factory: Annotated[list[int], Field(default_factory=list)]
+    nullable_int: Optional[int]
+    nullable_int_with_default: Optional[int] = 3
+    nullable_int_with_null_default: Optional[int] = None
 ```
 
 Executing with `--all-fields-required`:
@@ -170,13 +170,13 @@ pydantic2ts --module backend.api --output ./frontend/apiTypes.ts --all-fields-re
 
 ```ts
 export interface ExampleModel {
-  a: number;
-  b: number[];
-  c: "c";
-  d: number;
-  e: number | null;
-  f: number | null;
-  g: number | null;
+  literal_str_with_default: "c";
+  int_with_default: number;
+  int_with_pydantic_default: number;
+  int_list_with_default_factory: number[];
+  nullable_int: number | null;
+  nullable_int_with_default: number | null;
+  nullable_int_with_null_default: number | null;
 }
 ```
 
@@ -188,12 +188,16 @@ pydantic2ts --module backend.api --output ./frontend/apiTypes.ts
 
 ```ts
 export interface ExampleModel {
-  a?: number;
-  b?: number[];
-  c?: "c";
-  d?: number;
-  e: number | null;
-  f?: number | null;
-  g?: number | null;
+  literal_str_with_default?: "c";
+  int_with_default?: number;
+  int_with_pydantic_default?: number;
+  int_list_with_default_factory?: number[];
+  nullable_int: number | null; // optional if Pydantic V1
+  nullable_int_with_default?: number | null;
+  nullable_int_with_null_default?: number | null;
 }
 ```
+
+> [!NOTE]
+> If you're using Pydantic V1, `nullable_int` will also be optional (`nullable_int?: number | null`) when executing without `--all-fields-required`. See [Pydantic docs](https://docs.pydantic.dev/2.10/concepts/models/#required-fields):
+> > In Pydantic V1, fields annotated with `Optional` or `Any` would be given an implicit default of `None` even if no default was explicitly specified. This behavior has changed in Pydantic V2, and there are no longer any type annotations that will result in a field having an implicit default value.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The available inputs are documented here: https://github.com/phillipdupuis/pydan
 | &#8209;&#8209;output                          | name of the file the typescript definitions should be written to. Ex: './frontend/apiTypes.ts'                                                                                                                                          |
 | &#8209;&#8209;exclude                         | name of a pydantic model which should be omitted from the resulting typescript definitions. This option can be defined multiple times, ex: `--exclude Foo --exclude Bar` to exclude both the Foo and Bar models from the output.        |
 | &#8209;&#8209;json2ts&#8209;cmd               | optional, the command used to invoke json2ts. The default is 'json2ts'. Specify this if you have it installed locally (ex: 'yarn json2ts') or if the exact path to the executable is required (ex: /myproject/node_modules/bin/json2ts) |
-| &#8209;&#8209;all&#8209;fields&#8209;required | optional. Treats all fields (even those with defaults) as required in the generated TypeScript interfaces. (Pydantic v2 only)                                                                                                           |
+| &#8209;&#8209;all&#8209;fields&#8209;required | optional (off by default). Treats all fields as required (present) in the generated TypeScript interfaces.                                                                                                                              |
 
 ---
 
@@ -142,11 +142,11 @@ async function login(
 
 ### Treating all fields as required
 
-If you are using pydantic v2 and would like to treat all fields as required in the generated TypeScript interfaces, you can use the `--all-fields-required` flag.
+If you would like to treat all fields as required in the generated TypeScript interfaces, you can use the `--all-fields-required` flag.
 
-This is useful if you know that all fields will be present on the TypeScript side; for example, when representing a response from your Python backend API (since Pydantic will populate any missing fields with defaults before the response is sent to the client).
+This is useful, for example, when representing a response from your Python backend API—since Pydantic will populate any missing fields with defaults before sending the response.
 
-#### Example (pydantic v2)
+#### Example
 
 ```python
 from pydantic import BaseModel, Field
@@ -168,8 +168,6 @@ Executing with `--all-fields-required`:
 pydantic2ts --module backend.api --output ./frontend/apiTypes.ts --all-fields-required
 ```
 
-Generated TypeScript interface:
-
 ```ts
 export interface ExampleModel {
   a: number;
@@ -188,8 +186,6 @@ Executing without `--all-fields-required`:
 pydantic2ts --module backend.api --output ./frontend/apiTypes.ts
 ```
 
-Generated TypeScript interface:
-
 ```ts
 export interface ExampleModel {
   a?: number;
@@ -201,7 +197,3 @@ export interface ExampleModel {
   g?: number | null;
 }
 ```
-
-> [!NOTE]
-> Field `e` is required (not marked as optional) in the generated interface, even without the `--all-fields-required` flag. This is because, in Pydantic v2, fields annotated as `Optional[...]` or `Any` are no longer given an implicit default of `None`. See [Pydantic docs](https://docs.pydantic.dev/latest/concepts/models/#required-fields):
-> > [in Pydantic V2] there are no longer any type annotations that will result in a field having an implicit default value.

--- a/pydantic2ts/cli/script.py
+++ b/pydantic2ts/cli/script.py
@@ -331,7 +331,7 @@ def generate_typescript_defs(
     :param json2ts_cmd: optional, the command that will execute json2ts.
                         Provide this if the executable is not discoverable
                         or if it's locally installed (ex: 'yarn json2ts').
-    :param all_fields_required: optional, treat all v2 model fields (including
+    :param all_fields_required: optional, treat all model fields (including
                                 those with defaults) as required in generated
                                 TypeScript definitions.
     """
@@ -417,8 +417,7 @@ def parse_cli_args(args: Optional[List[str]] = None) -> argparse.Namespace:
         "--all-fields-required",
         action="store_true",
         default=False,
-        help="Treat all fields (including those with defaults) as required in generated TypeScript definitions.\n"
-        "(Currently supported only for Pydantic V2 models.)",
+        help="Treat all fields (including those with defaults) as required in generated TypeScript definitions.",
     )
     return parser.parse_args(args)
 

--- a/pydantic2ts/cli/script.py
+++ b/pydantic2ts/cli/script.py
@@ -32,6 +32,7 @@ import pydantic2ts.pydantic_v2 as v2
 if TYPE_CHECKING:  # pragma: no cover
     from pydantic import BaseModel as V2BaseModel
     from pydantic.config import ConfigDict
+    from pydantic.v1 import BaseModel as V1BaseModel
     from pydantic.v1.config import BaseConfig
     from pydantic.v1.fields import ModelField
 
@@ -283,7 +284,7 @@ def _schema_generation_overrides(
                 setattr(config, key, value)
 
 
-def _generate_json_schema(all_models: list[type], root_models: list[type], all_fields_required: bool = False) -> str:
+def _generate_json_schema(all_models: List[type], root_models: List[type], all_fields_required: bool = False) -> str:
     """
     Create a top-level '_Master_' model with references to each of the actual models.
     Generate the schema for this model, which will include the schemas for all the
@@ -326,8 +327,7 @@ def _collect_all_models(root_models: List[type]) -> List[type]:
     to collect all concrete model classes (BaseModel subclasses).
     """
     seen = set[type]()
-    result = list[type[v1.BaseModel] | type[v2.BaseModel]]()
-
+    result: List[Type[Union["V1BaseModel", "V2BaseModel"]]] = []
     def walk(type_: Any) -> None:
         if type_ in seen:
             return

--- a/pydantic2ts/cli/script.py
+++ b/pydantic2ts/cli/script.py
@@ -12,7 +12,6 @@ from tempfile import mkdtemp
 from types import ModuleType
 from typing import (
     TYPE_CHECKING,
-    Annotated,
     Any,
     Dict,
     Generator,
@@ -21,10 +20,10 @@ from typing import (
     Tuple,
     Type,
     Union,
-    get_args,
-    get_origin,
 )
 from uuid import uuid4
+
+from typing_extensions import Annotated, get_args, get_origin
 
 import pydantic2ts.pydantic_v1 as v1
 import pydantic2ts.pydantic_v2 as v2
@@ -284,7 +283,9 @@ def _schema_generation_overrides(
                 setattr(config, key, value)
 
 
-def _generate_json_schema(all_models: List[type], root_models: List[type], all_fields_required: bool = False) -> str:
+def _generate_json_schema(
+    all_models: List[type], root_models: List[type], all_fields_required: bool = False
+) -> str:
     """
     Create a top-level '_Master_' model with references to each of the actual models.
     Generate the schema for this model, which will include the schemas for all the
@@ -313,7 +314,11 @@ def _generate_json_schema(all_models: List[type], root_models: List[type], all_f
         for name, schema in defs.items():
             # Match the schema definition name back to the model class using its full qualified name
             matched_model: type | None = next(
-                (m for full_qn, m in all_models_by_full_qualname.items() if full_qn.endswith(f".{name}")),
+                (
+                    m
+                    for full_qn, m in all_models_by_full_qualname.items()
+                    if full_qn.endswith(f".{name}")
+                ),
                 None,
             )
             _clean_json_schema(schema, matched_model, all_fields_required=all_fields_required)
@@ -328,6 +333,7 @@ def _collect_all_models(root_models: List[type]) -> List[type]:
     """
     seen = set[type]()
     result: List[Type[Union["V1BaseModel", "V2BaseModel"]]] = []
+
     def walk(type_: Any) -> None:
         if type_ in seen:
             return
@@ -412,7 +418,9 @@ def generate_typescript_defs(
 
     LOG.info("Generating JSON schema from pydantic models...")
 
-    schema = _generate_json_schema(all_models=all_models, root_models=root_models, all_fields_required=all_fields_required)
+    schema = _generate_json_schema(
+        all_models=all_models, root_models=root_models, all_fields_required=all_fields_required
+    )
     schema_dir = mkdtemp()
     schema_file_path = os.path.join(schema_dir, "schema.json")
 

--- a/pydantic2ts/cli/script.py
+++ b/pydantic2ts/cli/script.py
@@ -172,6 +172,9 @@ def _clean_json_schema(
        resulting typescript file (which is a LOT of unnecessary noise).
     3) If it's a V1 model, ensure that nullability is properly represented.
        https://github.com/pydantic/pydantic/issues/1270
+    4) If all_fields_required is True, ensure that all properties are included in the
+       "required" list of the schema, so they don't get marked as optional in the
+       resulting typescript definitions.
     """
     description = schema.get("description")
 


### PR DESCRIPTION
## Summary

Fixes: #28

Adds an `--all-fields-required` option (defaults to `False`) that ensures no generated TypeScript interface fields are marked as optional (`fieldName?: ...`), even if they have default values or default factories in the Pydantic models.

## Motivation

Fields with defaults are viewed as optional by Pydantic, and thus currently become optional in the generated TypeScript interfaces.

This makes sense for API request schemas: clients don't need to provide values for these fields, since Pydantic can populate them with their defaults. However, for response schemas, the TS client should be able to know that these fields will be present, since Pydantic will populate them before sending the response data.

So, this new option (`--all-fields-required`) allows devs to represent response schemas without unnecessary optional markers (`?`) being added to fields that will always be present.

## Approach

The implementation is nice and simple: at the end of each `_clean_json_schema` call, if `--all-fields-required` is set, we ensure every property name in `schema["properties"]` is included in `schema["required"]`.

## Comparison to existing PR #31

An existing PR (#31, filed by @bibermann in 2022) implements a similar flag `--readonly-interfaces` and is also marked to resolve #28.

It takes a slightly different approach, only operating on Pydantic V1 models (Pydantic V2 didn't exist back then), and marking a field as required if `allow_none` is true.

Under that approach, fields could still be marked as optional in the generated TS interfaces. E.g. under `--readonly-interfaces`, [this](https://github.com/phillipdupuis/pydantic-to-typescript/pull/31/files#diff-14806a18cde8cc4629474c69cb6cc3d06f5f663de711f8c0b96c4d6bfe061442R17-R43):

```py
class Foo(BaseModel):
    required: str
    default: str = "foo"
    optional: Optional[str]
    optional_default: Optional[str] = "foo"
```

would be generated into [this](https://github.com/phillipdupuis/pydantic-to-typescript/pull/31/files#diff-8dc7c8f4a005aeaa1b42388f7cb3eca1eb9f1016eac6b0b5ec4a8f5f42a11a05R10-R28):

```ts
export interface Foo {
  required: string;
  default: string;
  optional?: string;
  optional_default?: string;
}
```

Whereas under `--all-fields-required` it would be generated into this:

```ts
export interface Foo {
  required: string;
  default: string;
  optional: string | null;
  optional_default: string | null;
}
```

As we can see, another difference in the outputs is the existence of `null` types, but that's because of the [pydantic2ts v2.0.0 release in Nov 2024](https://github.com/phillipdupuis/pydantic-to-typescript/pull/49/files#diff-5e42d339c5f77d296faf28bb1e6cec57fe8373d5ae65b531da49f827ef1a6cb8R186-R199).

## Note on required fields in Pydantic V1 vs V2

Under Pydantic V1, nullable fields were implicitly given default values of `None`, which the [Pydantic docs mention here](https://docs.pydantic.dev/2.10/concepts/models/#required-fields):

> [!NOTE]
> In Pydantic V1, fields annotated with Optional or Any would be given an implicit default of None even if no default was explicitly specified. This behavior has changed in Pydantic V2, and there are no longer any type annotations that will result in a field having an implicit default value.

But since `--all-fields-required` is just meant to mark every field as required whether or not it has a default or is nullable, our approach should be sound for either V1 or V2.