### PR TITLE
Fix bug when using --module foo and foo is a directory.

### DIFF
--- a/pydantic2ts/cli/script.py
+++ b/pydantic2ts/cli/script.py
@@ -47,7 +47,7 @@ def _import_module(path: str) -> ModuleType:
     definition exist in sys.modules under that name.
     """
     try:
-        if os.path.exists(path):
+        if os.path.exists(path) and os.path.isfile(path):
             name = uuid4().hex
             spec = spec_from_file_location(name, path, submodule_search_locations=[])
             assert spec is not None, f"spec_from_file_location failed for {path}"


### PR DESCRIPTION
* The current check would try to load that as a file and fail.
* Pointing to the file itself (foo/__init__.py) doesn't work because then the _is_submodule check fails, because the module name is a random UUID in that case.
* `PYTHONPATH=. pydantic2ts.py --module foo --output foo.ts` works in this case.